### PR TITLE
Update ConsoleApplication1.cpp

### DIFF
--- a/ConsoleApplication1/ConsoleApplication1.cpp
+++ b/ConsoleApplication1/ConsoleApplication1.cpp
@@ -298,14 +298,13 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 				set_steam_reg("AutoLoginUser", account[AccountName]);
 
 				if (is_process_running("steam.exe")) {
-					auto steam_shutdown = "start \"\" \"" + get_steam_reg("SteamExe") + "\"" + " -shutdown";
-					system(steam_shutdown.c_str());
+					ShellExecute(NULL, "open", get_steam_reg("SteamExe").c_str(), "-shutdown", NULL, SW_HIDE);
 
 					while (is_process_running("steam.exe"))
 						Sleep(100);
 				}
 
-				system("start steam://open/main");
+				ShellExecute(NULL, "open", "steam://open/main", NULL, NULL, SW_SHOWNORMAL);
 			}
 
 			break;


### PR DESCRIPTION
Refactor Steam shutdown and launch code to use ShellExecute() instead of system().

Replaced the first call to system() with a call to ShellExecute() to start Steam and initiate a shutdown, with the SW_HIDE flag to prevent a console window from appearing. Also replaced the second call to system() with a call to ShellExecute() to launch the Steam client, with the SW_SHOWNORMAL flag to display the window on the screen. These changes improve the user experience by avoiding the console window and making the Steam client visible when la